### PR TITLE
Fixing sharing of form state

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -15,8 +15,8 @@ exports.create = function(fields){
         bind: function(data){
             var b = {};
             b.toHTML = f.toHTML;
-            b.fields = f.fields;
-            Object.keys(b.fields).forEach(function(k){
+            b.fields = {};
+            Object.keys(f.fields).forEach(function(k){
                 b.fields[k] = f.fields[k].bind(data[k]);
             });
             b.data = Object.keys(b.fields).reduce(function(a,k){
@@ -25,7 +25,7 @@ exports.create = function(fields){
             }, {});
             b.validate = function(callback){
                 async.forEach(Object.keys(b.fields), function(k, callback){
-                    f.fields[k].validate(b, function(err, bound_field){
+                    b.fields[k].validate(b, function(err, bound_field){
                         b.fields[k] = bound_field;
                         callback(err);
                     });


### PR DESCRIPTION
Hello caolan!

Here is a 3-line fix to close issue 13, wherein a bound form would also bind data to the form prototype: (https://github.com/caolan/forms/issues/13). This was caused by a circular reference between the `fields` property of the prototype and the bound form.

With this change, only the bound form will have `value` and `data` attributes changed when bound, as expected.

Happy new year,

Fil
