### PR TITLE
Added additional object check in handle

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -44,7 +44,7 @@ exports.create = function (fields) {
             return b;
         },
         handle: function (obj, callbacks) {
-            if (typeof obj === 'undefined' || obj === null || !Object.keys(obj).length) {
+            if (typeof obj === 'undefined' || obj === null || (typeof obj === 'object' && Object.keys(obj).length === 0)) {
                 (callbacks.empty || callbacks.other)(f);
             } else if (obj instanceof http.IncomingMessage) {
                 if (obj.method === 'GET') {


### PR DESCRIPTION
I noticed when using with Express bodyParser that handle only checks for the existence of obj.body and then performs a validation check. This does not allow the 'empty' callback to be used. I've added a check to see if obj.body has been populated, and if not to allow the 'empty' callback to be invoked.
