### PR TITLE
Derbyjs Compatibility

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -66,9 +66,6 @@ exports.create = function (fields) {
                 } else {
                     throw new Error('Cannot handle request method: ' + obj.method);
                 }
-            } else if (Object.prototype.toString.call(obj) === '[object Array]') {
-                // assuming derby params
-                f.handle(obj.body, callbacks);
             } else if (typeof obj === 'object') {
                 f.bind(obj).validate(function (err, f) {
                     if (f.isValid()) {


### PR DESCRIPTION
Forms is almost completely compatible with Derbyjs. The provided patch allows forms to accept a derbyjs params array as input to its handle function.

I'm only a month into using NodeJS in general, so I'm all ears if you have concerns, however general.

One thing I noted is that you use instanceof and typeof in place of Object.prototype.toString.call, which is reportedly more reliable. The instanceof syntax, in particular, is limited in what it can check for, whereas Object.prototype.toString.call seems capable of handling almost all types.
