### PR TITLE
Store the field definition key as the field definition "name"

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -71,6 +71,7 @@ exports.string = function (opt) {
         return r;
     };
     f.toHTML = function (name, iterator) {
+        name = name || this.name;
         return (iterator || forms.render.div)(name, this);
     };
 

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -12,6 +12,9 @@ exports.render = require('./render');
 exports.validators = require('./validators');
 
 exports.create = function (fields) {
+    Object.keys(fields).forEach(function (k) {
+        fields[k].name = k;
+    });
     var f = {
         fields: fields,
         bind: function (data) {


### PR DESCRIPTION
Right now, manual field rendering requires knowing the name of the 'key' being rendered.

Like so: form.field.email.toHTML('email');

This patch removes the 'name' argument from the field.toHTML method.

Like so: form.field.email.toHTML();

Left how the Form calls toHTML alone so this works both ways.
