### PR TITLE
Add Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+language: node_js
+node_js:
+  - 0.6
+  - 0.8

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![build status](https://secure.travis-ci.org/caolan/forms.png)](http://travis-ci.org/caolan/forms)
+
 # Forms
 
 Constructing a good form by hand is a lot of work. Popular frameworks like


### PR DESCRIPTION
This adds the code changes necessary for Travis CI integration. Some minimal setup just needs to happen by @caolan on the [Travis CI website](https://travis-ci.org/). This lets the tests run automatically for each build and can also be configured to show if a pull request causes any tests to fail.

This an update of #32 which wouldn't work as written.
