### PR TITLE
fix TypeError in test "handle ServerRequest POST"

### DIFF
--- a/test/test-form.js
+++ b/test/test-form.js
@@ -272,6 +272,7 @@ exports['handle ServerRequest GET'] = function (test) {
 exports['handle ServerRequest POST'] = function (test) {
     var f = forms.create({field1: forms.fields.string()}),
         req = new http.IncomingMessage();
+    req.body = {field1: 'test'};
     req.method = 'POST';
     f.handle(req, {
         success: function (form) {


### PR DESCRIPTION
Immediately after cloning and running tests I received an error "TypeError: Cannot read property 'readable' of undefined".

This PR fixes it by declaring a POST data object.
