### PR TITLE
Add space between css classes in error messages

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -56,7 +56,7 @@ exports.string = function (opt) {
     };
     f.errorHTML = function () {
         var classes = typeof this.cssClasses !== 'undefined' ? coerceArray(this.cssClasses.error) : [];
-        return this.error ? '<p class="' + htmlEscape(['error_msg'].concat(classes).join('')) + '">' + this.error + '</p>' : '';
+        return this.error ? '<p class="' + htmlEscape(['error_msg'].concat(classes).join(' ')) + '">' + this.error + '</p>' : '';
     };
     f.labelText = function (name) {
         return this.label || name[0].toUpperCase() + name.substr(1).replace(underscoreRegExp, ' ');


### PR DESCRIPTION
The css classes on error messages were getting joined without spaces between them.
