### PR TITLE
Replace "!!!" with "doctype"

### DIFF
--- a/example/layout.jade
+++ b/example/layout.jade
@@ -1,4 +1,4 @@
-!!!
+doctype
 html
   head
     title Test forms for express.js


### PR DESCRIPTION
`!!!` shortcut for `doctype` is removed [at the release of Jade v1.0.0](https://github.com/visionmedia/jade/blob/master/History.md#100--2013-12-22).
