### PR TITLE
Improvements in flexibility and user-friendliness.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/
+.idea/

--- a/lib/validators.js
+++ b/lib/validators.js
@@ -3,6 +3,14 @@
 
 var util = require('util');
 
+function format(message) {
+    if (arguments.length < 2 || message.lastIndexOf('%s') >= 0) {
+        return util.format.apply(null, [message].concat(Array.prototype.splice.call(arguments, 1)))
+    } else {
+        return message
+    }
+}
+
 // From https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js#L1238-L1257
 var trim = (function () {
     var ws = "\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF",
@@ -19,7 +27,7 @@ exports.matchField = function (match_field, message) {
     if (!message) { message = 'Does not match %s.'; }
     return function (form, field, callback) {
         if (form.fields[match_field].data !== field.data) {
-            callback(util.format(message, match_field));
+            callback(format(message, match_field));
         } else {
             callback();
         }
@@ -27,10 +35,10 @@ exports.matchField = function (match_field, message) {
 };
 
 exports.required = function (message) {
-    if (!message) { message = '%s is required.'; }
+    if (!message) { message = 'This field is required.'; }
     return function (form, field, callback) {
         if (trim(field.data).length === 0) {
-            callback(util.format(message, field.name || 'This field'));
+            callback(format(message, field.name));
         } else {
             callback();
         }
@@ -43,7 +51,7 @@ exports.requiresFieldIfEmpty = function (alternate_field, message) {
         var alternateBlank = trim(form.fields[alternate_field].data).length === 0,
             fieldBlank = trim(field.data).length === 0;
         if (alternateBlank && fieldBlank) {
-            callback(util.format(message, field.name, alternate_field));
+            callback(format(message, field.name, alternate_field));
         } else {
             callback();
         }
@@ -58,7 +66,7 @@ exports.min = function (val, message) {
         if (field.data >= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -69,7 +77,7 @@ exports.max = function (val, message) {
         if (field.data <= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -80,7 +88,7 @@ exports.range = function (min, max, message) {
         if (field.data >= min && field.data <= max) {
             callback();
         } else {
-            callback(util.format(message, min, max));
+            callback(format(message, min, max));
         }
     };
 };
@@ -91,7 +99,7 @@ exports.minlength = function (val, message) {
         if (field.data.length >= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -102,7 +110,7 @@ exports.maxlength = function (val, message) {
         if (field.data.length <= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -113,7 +121,7 @@ exports.rangelength = function (min, max, message) {
         if (field.data.length >= min && field.data.length <= max) {
             callback();
         } else {
-            callback(util.format(message, min, max));
+            callback(format(message, min, max));
         }
     };
 };
@@ -173,5 +181,9 @@ exports.date = function (message) {
             callback(message);
         }
     };
+};
+
+exports.alphanumeric = function(message) {
+    return exports.regexp(/^[a-zA-Z0-9]*$/, message || 'Letters and numbers only.');
 };
 

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
     "description": "An easy way to create, parse, and validate forms",
     "main": "./index",
     "author": "Caolan McMahon",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "repository": {
         "type": "git",
         "url": "http://github.com/caolan/forms.git"

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -27,9 +27,9 @@ exports.required = function (test) {
         whitespaceFields = { field: { name: 'field', data: '  ' } },
         filledFields = { field: { name: 'field', data: 'foo' } };
     v({ fields: emptyFields }, emptyFields.field, function (err) {
-        test.equals(err, 'field is required.');
+        test.equals(err, 'This field is required.');
         v({ fields: whitespaceFields }, whitespaceFields.field, function (err) {
-            test.equals(err, 'field is required.');
+            test.equals(err, 'This field is required.');
             v({ fields: filledFields }, filledFields.field, function (err) {
                 test.equals(err, undefined);
                 test.done();
@@ -247,3 +247,40 @@ exports.color = function (test) {
     async.parallel(tests, test.done);
 };
 
+exports.nonFormatMessage1 = function (test) {
+    var v = validators.matchField('field1', 'f2 dnm f1'),
+        data = {
+            fields: {
+                field1: {data: 'one'},
+                field2: {data: 'two'}
+            }
+        };
+    v(data, data.fields.field2, function (err) {
+        test.equals(err, 'f2 dnm f1');
+        data.fields.field2.data = 'one';
+        v(data, data.fields.field2, function (err) {
+            test.equals(err, undefined);
+            test.done();
+        });
+    });
+}
+
+exports.nonFormatMessage2 = function (test) {
+    validators.min(100, '1234567890')('form', {data: 50}, function (err) {
+        test.equals(err, '1234567890');
+        validators.min(100)('form', {data: 100}, function (err) {
+            test.equals(err, undefined);
+            test.done();
+        });
+    });
+}
+
+exports.nonFormatMessage3 = function (test) {
+    validators.minlength(5, 'qwertyuiop')('form', {data: '1234'}, function (err) {
+        test.equals(err, 'qwertyuiop');
+        validators.minlength(5)('form', {data: '12345'}, function (err) {
+            test.equals(err, undefined);
+            test.done();
+        });
+    });
+};


### PR DESCRIPTION
- Made it so that the '%s' in error strings is optional so non-formatted strings can be used for errors where calling a field by name is unnecessary.
- Added an alphanumeric validator for convenience.
- Changed the default message of the required validator from '%s is required.' to 'This field is required.' because any sensibly laid out form already makes it obvious what field an error refers to.
