### PR TITLE
Made `%s` string formatting tokens optional in field validator error messages.

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -3,6 +3,14 @@
 
 var util = require('util');
 
+var format = function format(message) {
+    if (arguments.length < 2 || message.lastIndexOf('%s') >= 0) {
+        return util.format.apply(null, [message].concat(Array.prototype.slice.call(arguments, 1)));
+    } else {
+        return message;
+    }
+}
+
 // From https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js#L1238-L1257
 var trim = (function () {
     var ws = "\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF",
@@ -19,7 +27,7 @@ exports.matchField = function (match_field, message) {
     if (!message) { message = 'Does not match %s.'; }
     return function (form, field, callback) {
         if (form.fields[match_field].data !== field.data) {
-            callback(util.format(message, match_field));
+            callback(format(message, match_field));
         } else {
             callback();
         }
@@ -30,7 +38,7 @@ exports.required = function (message) {
     if (!message) { message = '%s is required.'; }
     return function (form, field, callback) {
         if (trim(field.data).length === 0) {
-            callback(util.format(message, field.name || 'This field'));
+            callback(format(message, field.name || 'This field'));
         } else {
             callback();
         }
@@ -43,7 +51,7 @@ exports.requiresFieldIfEmpty = function (alternate_field, message) {
         var alternateBlank = trim(form.fields[alternate_field].data).length === 0,
             fieldBlank = trim(field.data).length === 0;
         if (alternateBlank && fieldBlank) {
-            callback(util.format(message, field.name, alternate_field));
+            callback(format(message, field.name, alternate_field));
         } else {
             callback();
         }
@@ -58,7 +66,7 @@ exports.min = function (val, message) {
         if (field.data >= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -69,7 +77,7 @@ exports.max = function (val, message) {
         if (field.data <= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -80,7 +88,7 @@ exports.range = function (min, max, message) {
         if (field.data >= min && field.data <= max) {
             callback();
         } else {
-            callback(util.format(message, min, max));
+            callback(format(message, min, max));
         }
     };
 };
@@ -91,7 +99,7 @@ exports.minlength = function (val, message) {
         if (field.data.length >= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -102,7 +110,7 @@ exports.maxlength = function (val, message) {
         if (field.data.length <= val) {
             callback();
         } else {
-            callback(util.format(message, val));
+            callback(format(message, val));
         }
     };
 };
@@ -113,7 +121,7 @@ exports.rangelength = function (min, max, message) {
         if (field.data.length >= min && field.data.length <= max) {
             callback();
         } else {
-            callback(util.format(message, min, max));
+            callback(format(message, min, max));
         }
     };
 };

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -250,14 +250,14 @@ test('color', function (test) {
 });
 
 test('alphanumeric', function (test) {
-    function makeTest(message, data, expected) {
+    var makeTest = function (message, data, expected) {
         return function (callback) {
             validators.alphanumeric(message)('form', {data: data}, function(err) {
                 test.equal(err, expected);
                 callback();
             });
         };
-    }
+    };
 
     var tests = [
         makeTest(undefined, 'asdf', undefined),
@@ -271,3 +271,40 @@ test('alphanumeric', function (test) {
     async.parallel(tests, test.end);
 });
 
+test('nonFormatMessage1', function (test) {
+    var v = validators.matchField('field1', 'f2 dnm f1'),
+        data = {
+            fields: {
+                field1: {data: 'one'},
+                field2: {data: 'two'}
+            }
+        };
+    v(data, data.fields.field2, function (err) {
+        test.equals(err, 'f2 dnm f1');
+        data.fields.field2.data = 'one';
+        v(data, data.fields.field2, function (err) {
+            test.equals(err, undefined);
+            test.end();
+        });
+    });
+});
+
+test('nonFormatMessage2', function (test) {
+    validators.min(100, '1234567890')('form', {data: 50}, function (err) {
+        test.equals(err, '1234567890');
+        validators.min(100)('form', {data: 100}, function (err) {
+            test.equals(err, undefined);
+            test.end();
+        });
+    });
+});
+
+test('nonFormatMessage3', function (test) {
+    validators.minlength(5, 'qwertyuiop')('form', {data: '1234'}, function (err) {
+        test.equals(err, 'qwertyuiop');
+        validators.minlength(5)('form', {data: '12345'}, function (err) {
+            test.equals(err, undefined);
+            test.end();
+        });
+    });
+});


### PR DESCRIPTION
> can you provide more info about your use case? With regard to "any sensibly laid out form already makes it obvious what field an error refers to", not only are most forms not necessarily sensibly laid out, but clear text is absolutely critical for accessibility - how can a blind user, for example, know based on the layout which field an error refers to?

If an HTML form is unable to convey clearly which error goes with which field then either it is being read by a text-to-speech interface or it is in need of a redesign. In the case of the former, you already have defaults designed for this purpose. In the case of the latter, it's not yours or any library's job to undo a programmer's mistakes. Also, when I make a website for art or video games, I shouldn't and don't need to care whether blind people can use the site.

One of the more natural and flexible ways to render one of your forms is with the following Jade and CSS code:

``` jade
mixin form_normal(form)
    - var allRequired = true
    - for(var k in form.fields)
        - if(!form.fields[k].required)
            - allRequired = false

    .normalform
        each field in form.fields
            .row
                label(for=field.name)
                    != field.labelText()
                    if field.required && !allRequired
                        | *
                .io
                    != field.widget.toHTML(field.name, field)
                    .error
                        = field.error
        if !allRequired
            .helptext.
                Fields marked with * are required.
```

``` css
.normalform {
    margin-bottom: .75em;
}
.normalform label {
    display: table-cell;
    padding-right: .5em;
    font-size: .9em;
}
.normalform input {
    display: table-cell;
    border: 2px inset #3b7d96;
    width: 20em;
    background-color: #fafafa;

    -webkit-box-sizing: border-box;
    -moz-box-sizing: border-box;
    box-sizing: border-box;
}
.normalform .row {
    display: table-row;
}
.normalform .io {
    display: table-cell;
    padding-bottom: 1em;
}
.normalform .error {
    color: #ea0806;
    font-weight: bold;
}
.normalform .helptext {
    font-size: .7em;
    color: #686868;
}
```

The result is this:

![image](https://f.cloud.github.com/assets/3682658/2368943/8778192c-a7c4-11e3-94b3-6ab8708ff1d5.png)

It may not be the prettiest form but it's user-friendly. This may not be the best way to render it but it's a good one. Overall, it's a pretty good use case. This is what it looks like with the error messages made possible in my branch:

![image](https://f.cloud.github.com/assets/3682658/2368946/9041f1d6-a7c4-11e3-99db-ce8cf66c80e5.png)

Notice the error message with the field name nowhere in it yet still remaining perfectly descriptive in any kind of browser. The default would be "Does not match password.", which sounds robotic and/or foreign mostly because there are so many better ways to word that.

Granted, I could rename the password field so the message doesn't look so robotic but that restricts the grammar I can use and requires me to access the field's data with bracket syntax whenever I want to use spaces. Not to mention how obfuscatory it is to have such an apparently illogical identifier in your codebase. This kind of constraint also makes your library unsuitable for rendering more than one form within the same form tag - which is sometimes the most modular and maintainable way to design an interface - because of possible name collisions. If I wanted to name a field 'form_0_name', the resulting error message would be remarkably offputting to pretty much all users.
