### PR TITLE
Fixed null object error when a nested form is submitted but one of the subsections is missing.

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -29,7 +29,9 @@ exports.create = function (fields) {
             b.toHTML = f.toHTML;
             b.fields = {};
             Object.keys(f.fields).forEach(function (k) {
-                b.fields[k] = f.fields[k].bind(data[k]);
+                if (data[k] != null) {
+                    b.fields[k] = f.fields[k].bind(data[k]);
+                }
             });
             b.data = Object.keys(b.fields).reduce(function (a, k) {
                 a[k] = b.fields[k].data;

--- a/test/test-form.js
+++ b/test/test-form.js
@@ -224,6 +224,16 @@ test('handle empty object', function (t) {
     t.end();
 });
 
+test('handle missing multi-form section', function (t) {
+    t.plan(1);
+    var f = forms.create({
+        section1: {field1: forms.fields.string()},
+        section2: {field1: forms.fields.string()}
+    });
+    f.bind({section1: {field1: "string"}});
+    t.ok(true, 'Form handled missing section ok.');
+});
+
 test('handle error', function (t) {
     t.plan(5);
     var f = forms.create({field1: forms.fields.string()});


### PR DESCRIPTION
Fixes #90

Currently ignores the section if it's missing. You might want to add a validate for an entire section in the future but this works for now.
