### PR TITLE
continue to validate fields after first error

### DIFF
--- a/lib/forms.js
+++ b/lib/forms.js
@@ -14,7 +14,11 @@ exports.fields = require('./fields');
 exports.render = require('./render');
 exports.validators = require('./validators');
 
-exports.create = function (fields) {
+exports.create = function (fields, opts) {
+    if (!opts) { opts = {}; }
+
+    var validatePastFirstError = !!opts.validatePastFirstError;
+
     Object.keys(fields).forEach(function (k) {
         // if it's not a field object, create an object field.
         if (!is.fn(fields[k].toHTML) && is.object(fields[k])) {
@@ -46,7 +50,7 @@ exports.create = function (fields) {
                 async.forEach(Object.keys(b.fields), function (k, callback) {
                     b.fields[k].validate(b, function (err, bound_field) {
                         b.fields[k] = bound_field;
-                        callback(null);
+                        callback(validatePastFirstError ? null : err);
                     });
                 }, function (err) {
                     callback(err, b);

--- a/test/test-form.js
+++ b/test/test-form.js
@@ -329,18 +329,37 @@ test('handle ServerRequest POST', function (t) {
     req.emit('end');
 });
 
-test('handle ServerRequest POST and validate all fields', function (t) {
+test('validation stops on first error', function (t) {
     t.plan(3);
     var f = forms.create({
-        field1: forms.fields.string({ required: true }),
-        field2: forms.fields.string({ required: true }),
-        field3: forms.fields.string({ required: true }) }),
-        req = new http.IncomingMessage();
-    req.body = {field1: 'test'};
-    req.method = 'POST';
-    f.handle(req, {
+            field1: forms.fields.string({ required: true }),
+            field2: forms.fields.string({ required: true }),
+            field3: forms.fields.string({ required: true }) 
+        });
+    
+    f.handle({ field1: 'test' }, {
         error: function(form) {
-            t.equal(form.data.field1, 'test');
+            t.equal(form.fields.field1.error, undefined);
+            t.equal(form.fields.field2.error, 'field2 is required.');
+            t.equal(form.fields.field3.error, undefined);
+            t.end();
+        }
+    });
+});
+
+test('validates past first error with validatePastFirstError option', function (t) {
+    t.plan(3);
+    var f = forms.create({
+            field1: forms.fields.string({ required: true }),
+            field2: forms.fields.string({ required: true }),
+            field3: forms.fields.string({ required: true }) 
+        },{
+            validatePastFirstError: true
+        });
+
+    f.handle({ field1: 'test' }, {
+        error: function(form) {
+            t.equal(form.fields.field1.error, undefined);
             t.equal(form.fields.field2.error, 'field2 is required.');
             t.equal(form.fields.field3.error, 'field3 is required.');
             t.end();


### PR DESCRIPTION
I found only the first validation error was being reported when multiple fields were in error.

This was my scenario:

a form with three required fields (title, description, date):

``` js
var form = forms.create({
  title: fields.string({required: true}),
  description: fields.string({ required: true }),
  date: fields.date({ required: true })
});
```

submitting a form with empty values for each:

``` js
{ title: '', description: '', date: '' }
```

only getting back errors for the first field (title):

``` js
form.handle(req, {
  error: function(form){
    var errors = Object.keys(form.fields).map(function(f){
      return form.fields[f].error;
    });
    console.log('errors', errors);
  }
})
```

prints out:

```
errors [ 'title is required.', undefined, undefined ]
```

It seems more sensible to me to validate all fields in one go, to allow the user to correct everything; currently they would probably assume the fields without errors are valid, and only find out after correcting the first error.

I added one test, and it passes all the existing ones.

Thanks for the library too!
