### PR TITLE
Changed how multiSelect are bound to compare string values.

### DIFF
--- a/lib/widgets.js
+++ b/lib/widgets.js
@@ -230,7 +230,7 @@ exports.multipleSelect = function (opt) {
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         var optionsHTML = Object.keys(f.choices).reduce(function (html, k) {
-            var selected = Array.isArray(f.value) ? f.value.some(function (v) { return v === k; }) : (f.value && f.value === k);
+            var selected = Array.isArray(f.value) ? f.value.some(function (v) { return v.toString() === k.toString(); }) : (f.value && f.value === k);
             return html + tag('option', {
                 value: k,
                 selected: !!selected


### PR DESCRIPTION
Since values are rendered as string in the html I made
a comparison of the stringified versions of value and choices.

This makes life so much easier when you as in my case have 
mongo ObjectId objects but just want the string representation.
