### PR TITLE
Fix unable to disable ID attribute

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -81,7 +81,7 @@ exports.string = function (opt) {
     };
     f.labelHTML = function (name, id) {
         if (this.widget.type === 'hidden') { return ''; }
-        var forID = id || 'id_' + name;
+        var forID = id === false ? false : (id || 'id_' + name);
         return forms.widgets.label({
             classes: typeof this.cssClasses !== 'undefined' ? coerceArray(this.cssClasses.label) : [],
             content: this.labelText(name, id)

--- a/lib/widgets.js
+++ b/lib/widgets.js
@@ -33,7 +33,7 @@ var input = function (type) {
             return tag('input', [{
                 type: type,
                 name: name,
-                id: f.id || true,
+                id: f.id === false ? false : (f.id || true),
                 classes: w.classes,
                 value: w.formatValue(f.value)
             }, userAttrs, w.attrs || {}]);
@@ -93,7 +93,7 @@ exports.checkbox = function (opt) {
         return tag('input', [{
             type: 'checkbox',
             name: name,
-            id: f.id || true,
+            id: f.id === false ? false : (f.id || true),
             classes: w.classes,
             checked: !!f.value,
             value: 'on'
@@ -118,7 +118,7 @@ exports.select = function (opt) {
         }, '');
         return tag('select', [{
             name: name,
-            id: f.id || true,
+            id: f.id === false ? false : (f.id || true),
             classes: w.classes
         }, w.attrs || {}], optionsHTML);
     };
@@ -135,7 +135,7 @@ exports.textarea = function (opt) {
         if (!f) { f = {}; }
         return tag('textarea', [{
             name: name,
-            id: f.id || true,
+            id: f.id === false ? false : (f.id || true),
             classes: w.classes,
             rows: opt.rows || null,
             cols: opt.cols || null,
@@ -156,7 +156,7 @@ exports.multipleCheckbox = function (opt) {
         if (!f) { f = {}; }
         return Object.keys(f.choices).reduce(function (html, k) {
             // input element
-            var id = f.id ? f.id + '_' + k : 'id_' + name + '_' + k;
+            var id = f.id === false ? false : (f.id ? f.id + '_' + k : 'id_' + name + '_' + k);
             var checked = f.value && (Array.isArray(f.value) ? f.value.some(function (v) { return String(v) === String(k); }) : String(f.value) === String(k));
 
             html += tag('input', [{
@@ -202,7 +202,7 @@ exports.multipleRadio = function (opt) {
         if (!f) { f = {}; }
         return Object.keys(f.choices).reduce(function (html, k) {
             // input element
-            var id = f.id ? f.id + '_' + k : 'id_' + name + '_' + k;
+            var id = f.id === false ? false : (f.id ? f.id + '_' + k : 'id_' + name + '_' + k);
             var checked = f.value && (Array.isArray(f.value) ? f.value.some(function (v) { return String(v) === String(k); }) : String(f.value) === String(k));
 
             html += tag('input', [{
@@ -240,7 +240,7 @@ exports.multipleSelect = function (opt) {
         return tag('select', [{
             multiple: true,
             name: name,
-            id: f.id || true,
+            id: f.id === false ? false : (f.id || true),
             classes: w.classes
         }, w.attrs || {}], optionsHTML);
     };

--- a/test/test-render.js
+++ b/test/test-render.js
@@ -138,6 +138,22 @@ var testWrap = function (tag) {
         t.end();
     });
 
+    test(tag + ' label no id', function (t) {
+        var f = forms.create({
+            fieldname: forms.fields.string({
+                id: false
+            })
+        });
+        t.equal(
+            f.toHTML(forms.render[tag]),
+            '<' + tag + ' class="field">' +
+                '<label>Fieldname</label>' +
+                '<input type="text" name="fieldname" />' +
+            '</' + tag + '>'
+        );
+        t.end();
+    });
+
     test(tag + ' hidden label', function (t) {
         var f = forms.create({
             fieldname: forms.fields.string({


### PR DESCRIPTION
`tag.js` handles the case where the ID attribute is falsey and doesn't display it. `fields.js` short circuits this behavior by defaulting to `true` if the `id` attribute is set to false.
