### PR TITLE
Add support for custom attributes to all widgets

### DIFF
--- a/lib/widgets.js
+++ b/lib/widgets.js
@@ -39,12 +39,6 @@ var input = function (type) {
                 value: w.formatValue(f.value)
             }, userAttrs, w.attrs || {}]);
         };
-        w.getDataRegExp = function () {
-            return dataRegExp;
-        };
-        w.getAriaRegExp = function () {
-            return ariaRegExp;
-        };
         return w;
     };
 };
@@ -89,6 +83,7 @@ exports.checkbox = function (opt) {
         classes: opt.classes,
         type: 'checkbox'
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         return tag('input', [{
@@ -98,7 +93,7 @@ exports.checkbox = function (opt) {
             classes: w.classes,
             checked: !!f.value,
             value: 'on'
-        }, w.attrs || {}]);
+        }, userAttrs, w.attrs || {}]);
     };
     return w;
 };
@@ -109,6 +104,7 @@ exports.select = function (opt) {
         classes: opt.classes,
         type: 'select'
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         var optionsHTML = Object.keys(f.choices).reduce(function (html, k) {
@@ -121,7 +117,7 @@ exports.select = function (opt) {
             name: name,
             id: f.id === false ? false : (f.id || true),
             classes: w.classes
-        }, w.attrs || {}], optionsHTML);
+        }, userAttrs, w.attrs || {}], optionsHTML);
     };
     return w;
 };
@@ -132,6 +128,7 @@ exports.textarea = function (opt) {
         classes: opt.classes,
         type: 'textarea'
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         return tag('textarea', [{
@@ -139,9 +136,8 @@ exports.textarea = function (opt) {
             id: f.id === false ? false : (f.id || true),
             classes: w.classes,
             rows: opt.rows || null,
-            cols: opt.cols || null,
-            placeholder: opt.placeholder || null
-        }, w.attrs || {}], f.value || '');
+            cols: opt.cols || null
+        }, userAttrs, w.attrs || {}], f.value || '');
     };
     return w;
 };
@@ -153,6 +149,7 @@ exports.multipleCheckbox = function (opt) {
         labelClasses: opt.labelClasses,
         type: 'multipleCheckbox'
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         return Object.keys(f.choices).reduce(function (html, k) {
@@ -167,7 +164,7 @@ exports.multipleCheckbox = function (opt) {
                 classes: w.classes,
                 value: k,
                 checked: !!checked
-            }, w.attrs || {}]);
+            }, userAttrs, w.attrs || {}]);
 
             // label element
             html += tag('label', {'for': id, classes: w.labelClasses}, f.choices[k]);
@@ -183,11 +180,12 @@ exports.label = function (opt) {
     var w = {
         classes: opt.classes || []
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (forID, f) {
         return tag('label', [{
             for: forID,
             classes: w.classes
-        }, w.attrs || {}], opt.content);
+        }, userAttrs, w.attrs || {}], opt.content);
     };
     return w;
 };
@@ -199,6 +197,7 @@ exports.multipleRadio = function (opt) {
         labelClasses: opt.labelClasses,
         type: 'multipleRadio'
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         return Object.keys(f.choices).reduce(function (html, k) {
@@ -213,7 +212,7 @@ exports.multipleRadio = function (opt) {
                 classes: w.classes,
                 value: k,
                 checked: !!checked
-            }, w.attrs || {}]);
+            }, userAttrs, w.attrs || {}]);
             // label element
             html += tag('label', {'for': id, classes: w.labelClasses}, f.choices[k]);
 
@@ -229,6 +228,7 @@ exports.multipleSelect = function (opt) {
         classes: opt.classes,
         type: 'multipleSelect'
     };
+    var userAttrs = getUserAttrs(opt);
     w.toHTML = function (name, f) {
         if (!f) { f = {}; }
         var optionsHTML = Object.keys(f.choices).reduce(function (html, k) {
@@ -243,7 +243,7 @@ exports.multipleSelect = function (opt) {
             name: name,
             id: f.id === false ? false : (f.id || true),
             classes: w.classes
-        }, w.attrs || {}], optionsHTML);
+        }, userAttrs, w.attrs || {}], optionsHTML);
     };
     return w;
 };

--- a/test/test-widgets.js
+++ b/test/test-widgets.js
@@ -144,7 +144,7 @@ test('textarea', function (t) {
             cols: 80,
             placeholder: 'hi!'
         }).toHTML('name', {id: 'someid', value: 'value'}),
-        '<textarea name="name" id="someid" rows="20" cols="80" placeholder="hi!" class="one two">value</textarea>'
+        '<textarea name="name" id="someid" rows="20" cols="80" class="one two" placeholder="hi!">value</textarea>'
     );
     t.equal(forms.widgets.textarea().type, 'textarea');
     t.end();
@@ -452,15 +452,134 @@ test('optional text input', function (t) {
     t.end();
 });
 
-test('optional data attribute regex test', function (t) {
-    var re = forms.widgets.text().getDataRegExp();
-    t.equal(re.test('data-'), false);
-    t.equal(re.test('data-input'), true);
-    t.equal(re.test('idata-input'), false);
-    t.equal(re.test('data-input1'), false);
-    t.equal(re.test('data_input'), false);
-    t.equal(re.test('data--'), false);
-    t.equal(re.test('data-foo-bar'), true);
+test('custom attributes', function (t) {
+    // regex tests
+    t.equal(
+        forms.widgets.text({
+            'data-': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" />'
+    );
+    t.equal(
+        forms.widgets.text({
+            'data-input': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" data-input="foo" />'
+    );
+    t.equal(
+        forms.widgets.text({
+            'idata-input': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" />'
+    );
+    t.equal(
+        forms.widgets.text({
+            'data-input1': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" />'
+    );
+    t.equal(
+        forms.widgets.text({
+            data_input: 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" />'
+    );
+    t.equal(
+        forms.widgets.text({
+            'data--': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" />'
+    );
+    t.equal(
+        forms.widgets.text({
+            'data-foo-bar': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="text" name="fieldWithAttrs" id="id_fieldWithAttrs" data-foo-bar="foo" />'
+    );
+
+    // widgets not based on the "input" widget should support optional attributes
+    t.equal(
+        forms.widgets.textarea({
+            'data-test': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<textarea name="fieldWithAttrs" id="id_fieldWithAttrs" data-test="foo"></textarea>'
+    );
+    t.equal(
+        forms.widgets.label({
+            'data-test': 'foo',
+            content: 'Foobar'
+        }).toHTML('fieldWithAttrs'),
+        '<label for="fieldWithAttrs" data-test="foo">Foobar</label>'
+    );
+    t.equal(
+        forms.widgets.checkbox({
+            'data-test': 'foo'
+        }).toHTML('fieldWithAttrs'),
+        '<input type="checkbox" name="fieldWithAttrs" id="id_fieldWithAttrs" value="on" data-test="foo" />'
+    );
+    t.equal(
+        forms.widgets.select({
+            'data-test': 'foo',
+        }).toHTML('name', {
+            choices: {
+                val1: 'text1',
+                val2: 'text2'
+            }
+        }),
+        '<select name="name" id="id_name" data-test="foo">' +
+            '<option value="val1">text1</option>' +
+            '<option value="val2">text2</option>' +
+        '</select>'
+    );
+    t.equal(
+        forms.widgets.multipleSelect({
+            'data-test': 'foo',
+        }).toHTML('name', {
+            choices: {
+                val1: 'text1',
+                val2: 'text2'
+            }
+        }),
+        '<select multiple="multiple" name="name" id="id_name" data-test="foo">' +
+            '<option value="val1">text1</option>' +
+            '<option value="val2">text2</option>' +
+        '</select>'
+    );
+
+    var w = forms.widgets.multipleCheckbox({
+        'data-test': 'foo'
+    });
+    var field = {
+        choices: {one: 'Item one', two: 'Item two', three: 'Item three'},
+        value: 'two'
+    };
+    t.equal(
+        w.toHTML('name', field),
+        '<input type="checkbox" name="name" id="id_name_one" value="one" data-test="foo" />' +
+        '<label for="id_name_one">Item one</label>' +
+        '<input type="checkbox" name="name" id="id_name_two" value="two" checked="checked" data-test="foo" />' +
+        '<label for="id_name_two">Item two</label>' +
+        '<input type="checkbox" name="name" id="id_name_three" value="three" data-test="foo" />' +
+        '<label for="id_name_three">Item three</label>'
+    );
+
+    var w = forms.widgets.multipleRadio({
+        'data-test': 'foo'
+    });
+    var field = {
+        choices: {one: 'Item one', two: 'Item two', three: 'Item three'},
+        value: 'two'
+    };
+    t.equal(
+        w.toHTML('name', field),
+        '<input type="radio" name="name" id="id_name_one" value="one" data-test="foo" />' +
+        '<label for="id_name_one">Item one</label>' +
+        '<input type="radio" name="name" id="id_name_two" value="two" checked="checked" data-test="foo" />' +
+        '<label for="id_name_two">Item two</label>' +
+        '<input type="radio" name="name" id="id_name_three" value="three" data-test="foo" />' +
+        '<label for="id_name_three">Item three</label>'
+    );
+
     t.end();
 });
 


### PR DESCRIPTION
This commit adds support for custom attributes to all widgets. Tests are there as well.

Please note that I rewrote the data attribute regex tests in order to not expose the `getDataRegExp` and `getAriaRegExp` functions.

Cheers,
Patrick
