### PR TITLE
Allow empty attribute values

### DIFF
--- a/lib/tag.js
+++ b/lib/tag.js
@@ -14,8 +14,6 @@ var attrs = function attrs(a) {
         var value = a[field];
         if (typeof value === 'boolean') {
             value = value ? field : null;
-        } else if (typeof value === 'string' && value.length === 0) {
-            value = null;
         } else if (typeof value === 'number' && isNaN(value)) {
             value = null;
         }

--- a/test-browser.js
+++ b/test-browser.js
@@ -5,6 +5,7 @@
      // require('./test/test-form'); // disabled until server-specific tests are split out
      require('./test/test-forms');
      require('./test/test-render');
+     require('./test/test-tag');
      // require('./test/test-validators'); // disabled until this unicode fix is merged: https://github.com/substack/testling/pull/35
      require('./test/test-widgets');
 }());

--- a/test/test-tag.js
+++ b/test/test-tag.js
@@ -2,6 +2,7 @@
 'use strict';
 var test = require('tape');
 var tag = require('../lib/tag');
+var forms = require('../');
 
 test('generates a self-closing tag', function (t) {
     var attrs = {
@@ -20,6 +21,33 @@ test('generates a non-self-closing tag', function (t) {
     };
     var html = tag('div', attrs, 'some content');
     t.equal(html, '<div data-foo="baz" class="foo bar">some content</div>');
+    t.end();
+});
+
+test('allow empty attributes', function (t) {
+    var html = forms.widgets.select().toHTML('field', {
+        choices: {
+            '': 'Make a choice',
+            choice1: 'Choice 1',
+            choice2: 'Choice 2'
+        }
+    });
+    t.equal(html,
+        '<select name="field" id="id_field">' +
+            '<option value="">Make a choice</option>' +
+            '<option value="choice1">Choice 1</option>' +
+            '<option value="choice2">Choice 2</option>' +
+        '</select>'
+    );
+
+    var html = forms.widgets.text({
+        'data-empty': ''
+    }).toHTML('field');
+
+    t.equal(html,
+        '<input type="text" name="field" id="id_field" data-empty="" />'
+    );
+
     t.end();
 });
 


### PR DESCRIPTION
I was running into an issue where I wanted to set an empty value for an `<option>` tag. This is basically the default behavior to define a placeholder for select fields.

``` javascript
choices = {
  '': 'Make a choice',
  'choice1': 'Choice 1',
  'choice2': 'Choice 2'
}
```

This generates the following markup:

``` HTML
<select>
  <option>Make a choice</option>
  <option value="choice1">Choice 1</option>
  <option value="choice2">Choice 2</option>
</select>
```

The problem is that browsers use the text between the option tag as a value if the corresponding attribute is missing ([docs](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/option#Attributes)). In the example above, the value is implicitly set to "Make a choice" instead of null.

This commit fixes the tag rendering to allow empty attributes:

``` HTML
<select>
  <option value="">Make a choice</option>
  <option value="choice1">Choice 1</option>
  <option value="choice2">Choice 2</option>
</select>
```
