### PR TITLE
Adding Bootstrap 3 Validation status classes to widget documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,9 +142,13 @@ var bootstrapField = function (name, object) {
     object.widget.classes.push('form-control');
 
     var label = object.labelHTML(name);
-    var error = object.error ? '<div class="alert alert-error">' + object.error + '</div>' : '';
+    var error = object.error ? '<div class="alert alert-error help-block">' + object.error + '</div>' : '';
+
+    var validationclass = object.value && !object.error ? 'has-success' : '';
+    validationclass = object.error ? 'has-error' : validationclass;
+
     var widget = object.widget.toHTML(name, object);
-    return '<div class="form-group">' + label + widget + error + '</div>';
+    return '<div class="form-group ' + validationclass + '">' + label + widget + error + '</div>';
 };
 ```
 


### PR DESCRIPTION
I added a couple of CSS classes to the widget docs on the README. These leverage the Bootstrap colour highlighting of validation states on the form. See here: http://getbootstrap.com/css/#forms-control-validation
