### PR TITLE
Error message field names should use label text, not raw field name

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -12,6 +12,17 @@ var format = function format(message) {
     }
 }
 
+var formatFieldName = function formatFieldName(field) {
+    var defaultFieldName = 'This field';
+
+    //in regular use, labelText is a defined function, but it's not when running tests.
+    if (typeof field.labelText === 'function') {
+        return field.name ? field.labelText(field.name) : defaultFieldName;
+    } else {
+        return field.name || defaultFieldName;
+    }
+}
+
 // From https://github.com/kriskowal/es5-shim/blob/master/es5-shim.js#L1238-L1257
 var trim = (function () {
     var ws = '\x09\x0A\x0B\x0C\x0D\x20\xA0\u1680\u180E\u2000\u2001\u2002\u2003\u2004\u2005\u2006\u2007\u2008\u2009\u200A\u202F\u205F\u3000\u2028\u2029\uFEFF',
@@ -43,7 +54,7 @@ exports.matchValue = function (valueGetter, message) {
     return function (form, field, callback) {
         var expected = valueGetter();
         if (field.data !== expected) {
-            callback(format(message, field.name || 'This field', expected));
+            callback(format(message, formatFieldName(field), expected));
         } else {
             callback();
         }
@@ -54,7 +65,7 @@ exports.required = function (message) {
     if (!message) { message = '%s is required.'; }
     return function (form, field, callback) {
         if (trim(field.data).length === 0) {
-            callback(format(message, field.name || 'This field'));
+            callback(format(message, formatFieldName(field)));
         } else {
             callback();
         }
@@ -67,7 +78,7 @@ exports.requiresFieldIfEmpty = function (alternate_field, message) {
         var alternateBlank = trim(form.fields[alternate_field].data).length === 0;
         var fieldBlank = trim(field.data).length === 0;
         if (alternateBlank && fieldBlank) {
-            callback(format(message, field.name, alternate_field));
+            callback(format(message, formatFieldName(field), alternate_field));
         } else {
             callback();
         }

--- a/test/test-form.js
+++ b/test/test-form.js
@@ -393,7 +393,7 @@ test('validation stops on first error', function (t) {
     f.handle({ field1: 'test' }, {
         error: function (form) {
             t.equal(form.fields.field1.error, undefined);
-            t.equal(form.fields.field2.error, 'field2 is required.');
+            t.equal(form.fields.field2.error, 'Field2 is required.');
             t.equal(form.fields.field3.error, undefined);
             t.end();
         }
@@ -413,8 +413,8 @@ test('validates past first error with validatePastFirstError option', function (
     f.handle({ field1: 'test' }, {
         error: function (form) {
             t.equal(form.fields.field1.error, undefined);
-            t.equal(form.fields.field2.error, 'field2 is required.');
-            t.equal(form.fields.field3.error, 'field3 is required.');
+            t.equal(form.fields.field2.error, 'Field2 is required.');
+            t.equal(form.fields.field3.error, 'Field3 is required.');
             t.end();
         }
     });


### PR DESCRIPTION
This causes the tests in test-validators to fail with 

```
TypeError: Object #<Object> has no method 'labelText'
at exports.matchValue (/Users/ryan.french/Documents/Code/RYFN/forms/lib/validators.js:46:44)
```

However, there is a labelText method available when in regular use - the `field` object has all the methods in `lib/fields.js`

What can I do to resolve this?
