### PR TITLE
Introducing placeholder text for input fields

### DIFF
--- a/lib/widgets.js
+++ b/lib/widgets.js
@@ -35,6 +35,7 @@ var input = function (type) {
                 name: name,
                 id: f.id === false ? false : (f.id || true),
                 classes: w.classes,
+                placeholder: f.placeholder,
                 value: w.formatValue(f.value)
             };
             return tag('input', [attrs, userAttrs, w.attrs || {}]);


### PR DESCRIPTION
Introducing placeholder text for input fields.
While specifying the field "placeholder" property can also be provided.
ex:
    email: fields.email({
        required: validators.required("Please provide the email address"),
        widget: widgets.email(),
        errorAfterField: true,
        placeholder: "Email Address",
        label: "Email"
    })

It is upto the user to specify label and/or placeholder