### PR TITLE
Fix the issue that date tag is missing

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -174,6 +174,7 @@ exports.date = function (opt) {
     } else {
         f.validators = [forms.validators.date()];
     }
+    if (!opts.widget) { f.widget = forms.widgets.date(opts.attrs || {}); }
     return f;
 };
 


### PR DESCRIPTION
Fix the problem that `fields.date() `generates html codes `<type="text">` instead of `<type="date">`