### PR TITLE
Remove redundant conditional

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -10,7 +10,7 @@ var tag = require('./tag');
 var validators = require('./validators');
 
 var coerceArray = function (arr) {
-    return is.array(arr) && arr.length > 0 ? arr : [];
+    return is.array(arr) ? arr : [];
 };
 var nameSeparatorRegExp = /[_-]/g;
 


### PR DESCRIPTION
`is.array(arr) && arr.length > 0 ? arr : [];` is logically equivalent `is.array(arr) ? arr : [];`.

Just a small fix!