### PR TITLE
Fixed RangeLength Validators for Numbers

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -112,7 +112,7 @@ exports.range = function (min, max, message) {
 exports.minlength = function (val, message) {
     var msg = message || 'Please enter at least %s characters.';
     return function (form, field, callback) {
-        if (field.data.length >= val) {
+        if (String(field.data).length >= val) {
             callback();
         } else {
             callback(format(msg, val));
@@ -123,7 +123,7 @@ exports.minlength = function (val, message) {
 exports.maxlength = function (val, message) {
     var msg = message || 'Please enter no more than %s characters.';
     return function (form, field, callback) {
-        if (field.data.length <= val) {
+        if (String(field.data).length <= val) {
             callback();
         } else {
             callback(format(msg, val));
@@ -134,7 +134,7 @@ exports.maxlength = function (val, message) {
 exports.rangelength = function (min, max, message) {
     var msg = message || 'Please enter a value between %s and %s characters long.';
     return function (form, field, callback) {
-        if (field.data.length >= min && field.data.length <= max) {
+        if (String(field.data).length >= min && String(field.data).length <= max) {
             callback();
         } else {
             callback(format(msg, min, max));

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -208,29 +208,41 @@ test('date', function (t) {
 });
 
 test('minlength', function (t) {
-    t.plan(2);
+    t.plan(4);
     validators.minlength(5, 'Enter at least %s characters.')('form', { data: '1234' }, function (tooShortError) {
         t.equal(tooShortError, 'Enter at least 5 characters.');
         validators.minlength(5)('form', { data: '12345' }, function (err) {
             t.equal(err, undefined);
-            t.end();
         });
     });
+    validators.minlength(5, 'Enter at least %s characters.')('form', { data: 12345 }, function (err) {
+        t.equal(err, undefined);
+    });
+    validators.minlength(5, 'Enter at least %s characters.')('form', { data: 1234 }, function (err) {
+        t.equal(err, 'Enter at least 5 characters.');
+    });
+    t.end();
 });
 
 test('maxlength', function (t) {
-    t.plan(2);
+    t.plan(4);
     validators.maxlength(5)('form', { data: '123456' }, function (tooLongError) {
         t.equal(tooLongError, 'Please enter no more than 5 characters.');
         validators.maxlength(5)('form', { data: '12345' }, function (err) {
             t.equal(err, undefined);
-            t.end();
         });
     });
+    validators.maxlength(5, 'Please enter no more than 5 characters.')('form', { data: 12345 }, function (err) {
+        t.equal(err, undefined);
+    });
+    validators.maxlength(5, 'Please enter no more than 5 characters.')('form', { data: 123456 }, function (err) {
+        t.equal(err, 'Please enter no more than 5 characters.');
+    });
+    t.end();
 });
 
 test('rangelength', function (t) {
-    t.plan(4);
+    t.plan(8);
     validators.rangelength(2, 4, 'Enter between %s and %s characters.')('form', { data: '12345' }, function (err) {
         t.equal(err, 'Enter between 2 and 4 characters.');
     });
@@ -241,6 +253,18 @@ test('rangelength', function (t) {
         t.equal(err, undefined);
     });
     validators.rangelength(2, 4)('form', { data: '1234' }, function (err) {
+        t.equal(err, undefined);
+    });
+    validators.rangelength(2, 4, 'Enter between %s and %s characters.')('form', { data: 12345 }, function (err) {
+        t.equal(err, 'Enter between 2 and 4 characters.');
+    });
+    validators.rangelength(2, 4)('form', { data: 1 }, function (err) {
+        t.equal(err, 'Please enter a value between 2 and 4 characters long.');
+    });
+    validators.rangelength(2, 4)('form', { data: 12 }, function (err) {
+        t.equal(err, undefined);
+    });
+    validators.rangelength(2, 4)('form', { data: 1234 }, function (err) {
         t.equal(err, undefined);
     });
     t.end();


### PR DESCRIPTION
The minLength, maxLength, and RangeLength validators were not working on number inputs. Lets say we wanted to check if '12345' had a minimum of 4 digits, minLength would fail in this case because field.data.length would be undefined for a number data type. Performing a toString() on it fixes this.