### PR TITLE
upgrade async to fix npm audit issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "forms",
-    "version": "1.3.1",
+    "version": "1.3.2",
     "description": "An easy way to create, parse, and validate forms",
     "main": "./index",
     "author": "Caolan McMahon",
@@ -35,7 +35,7 @@
     "dependencies": {
         "array.prototype.every": "^1.0.0",
         "array.prototype.some": "^1.0.0",
-        "async": "^2.6.2",
+        "async": "^2.6.3",
         "formidable": "^1.2.1",
         "is": "^3.3.0",
         "object-keys": "^1.1.1",


### PR DESCRIPTION
lodash has a high-severity npm audit issue on versions < 4.17.12 and async 2.6.2 & below uses an earlier version of lodash, so I updated it to async 2.6.3 & bumped the version

Closes #210.