### PR TITLE
Replace email validator

### DIFF
--- a/lib/validators.js
+++ b/lib/validators.js
@@ -4,6 +4,7 @@ var util = require('util');
 var is = require('is');
 var trim = require('string.prototype.trim');
 var every = require('array.prototype.every');
+var emailValidator = require('email-addresses');
 
 var format = function format(message) {
     if (arguments.length < 2 || message.lastIndexOf('%s') >= 0) {
@@ -168,10 +169,14 @@ exports.color = function (message) {
 
 exports.email = function (message) {
     var msg = message || 'Please enter a valid email address.';
-    // regular expression by Scott Gonzalez:
-    // http://projects.scottsplayground.com/email_address_validation/
-    // eslint-disable-next-line no-control-regex, no-useless-escape
-    return exports.regexp(/^((([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+(\.([a-z]|\d|[!#\$%&'\*\+\-\/=\?\^_`{\|}~]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])+)*)|((\x22)((((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(([\x01-\x08\x0b\x0c\x0e-\x1f\x7f]|\x21|[\x23-\x5b]|[\x5d-\x7e]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(\\([\x01-\x09\x0b\x0c\x0d-\x7f]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF]))))*(((\x20|\x09)*(\x0d\x0a))?(\x20|\x09)+)?(\x22)))@((([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|\d|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.)+(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])|(([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])([a-z]|\d|-|\.|_|~|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])*([a-z]|[\u00A0-\uD7FF\uF900-\uFDCF\uFDF0-\uFFEF])))\.?$/i, msg);
+    return function (form, field, callback) {
+        var object = emailValidator.parseOneAddress(field.data);
+        if (object) {
+            callback();
+        } else {
+            callback(msg);
+        }
+    };
 };
 
 exports.url = function (include_localhost, message) {

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
         "array.prototype.every": "^1.1.0",
         "array.prototype.some": "^1.1.1",
         "async": "^2.6.3",
+        "email-addresses": "^3.1.0",
         "formidable": "^1.2.2",
         "is": "^3.3.0",
         "object-keys": "^1.1.1",

--- a/test/test-validators.js
+++ b/test/test-validators.js
@@ -171,7 +171,7 @@ test('email', function (t) {
         t.equal(err, undefined, 'a←+b@f.museum');
     });
     v('form', { data: 'asdf(with comments)@example.com' }, function (err) {
-        t.equal(err, 'Please enter a valid email address.', 'asdf(with comments)@example.com');
+        t.error(err, 'asdf(with comments)@example.com');
     });
     v('form', { data: '"quoted"@example.com' }, function (err) {
         t.error(err, '"quoted"@example.com');
@@ -182,8 +182,8 @@ test('email', function (t) {
     v('form', { data: '"quoted@at"@example.com' }, function (err) {
         t.error(err, '"quoted@at"@example.com');
     });
-    v('form', { data: '"aaaaaaaaaaaaaaaaaaaaaaaaa' }, function (err) {
-        t.equal(err, 'Please enter a valid email address.', '"aaaaaaaaaaaaaaaaaaaaaaaaa');
+    v('form', { data: '"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa' }, function (err) {
+        t.equal(err, 'Please enter a valid email address.', 'lots of a’s');
     });
     t.end();
 });


### PR DESCRIPTION
This limits emails to "sane" emails which doesn't allow legacy features like quoted parts, comments, etc. This is more likely to be what people actually expect in an email address.