### PR TITLE
Add a promised based handle()

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -3,6 +3,10 @@
 
 	"extends": "@ljharb",
 
+	"globals": {
+		"Promise": false,
+	},
+
 	"rules": {
 		"callback-return": 0,
 		"camelcase": 0,

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -71,7 +71,23 @@ exports.create = function (fields, options) {
             };
             return b;
         },
-        handle: function (obj, callbacks) {
+        handle: function (obj, rawCallbacks) {
+            var returnValue;
+            var callbacks = rawCallbacks;
+
+            if (!callbacks) {
+                if (typeof Promise !== 'function') {
+                    throw new Error('Callbacks are required when Promises are unsupported');
+                }
+                returnValue = new Promise(function (resolve) {
+                    callbacks = {
+                        success: function (form) { return resolve({ success: true, form: form }); },
+                        error: function (form) { return resolve({ error: true, form: form }); },
+                        empty: function (form) { return resolve({ empty: true, form: form }); }
+                    };
+                });
+            }
+
             if (typeof obj === 'undefined' || obj === null || (is.object(obj) && is.empty(obj))) {
                 (callbacks.empty || callbacks.other)(f, callbacks);
             } else if (obj instanceof http.IncomingMessage) {
@@ -109,6 +125,8 @@ exports.create = function (fields, options) {
             } else {
                 throw new Error('Cannot handle type: ' + typeof obj);
             }
+
+            return returnValue;
         },
         toHTML: function () {
             var form = this;


### PR DESCRIPTION
Nowadays my feeling is that `promise`/`async`/`await` is pretty much the standard way of doing asynchronous development in node.js, so in my own projects and [the projects I did](https://github.com/Sydsvenskan/node-forms-utils/blob/22e8390f9eaad0d1eecc52ea00fcdaf032c5ccd0/lib/promise.js#L37-L46) at @sydsvenskan  I use a wrapper that makes `.handle()` be promised based.

This is that wrapper upstreamed to be part of `handle()` itself, making the `callbacks` argument optional and when it's omitted, instead a promise is returned.