### PR TITLE
Promise variants of form.validate() and field.validate()

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -52,10 +52,10 @@ exports.string = function (options) {
                     if (!b.error) {
                         v(form, b, function (v_err) {
                             b.error = v_err ? String(v_err) : null;
-                            asyncCallback(null);
+                            asyncCallback(b.error);
                         });
                     } else {
-                        asyncCallback(null);
+                        asyncCallback(b.error);
                     }
                 }, function (err) {
                     callback(err, b);

--- a/lib/fields.js
+++ b/lib/fields.js
@@ -30,7 +30,28 @@ exports.string = function (options) {
         var b = assign({}, f); // clone field object:
         b.value = raw_data;
         b.data = b.parse(raw_data);
-        b.validate = function (form, callback) {
+        b.validate = function (form, rawCallback) {
+            var callback = rawCallback;
+            var returnValue;
+
+            if (!callback) {
+                if (typeof Promise !== 'function') {
+                    throw new Error('Callback is required when Promises are unsupported');
+                }
+                returnValue = new Promise(function (resolve) {
+                    callback = function (err, bound_field) {
+                        if (err) {
+                            resolve({
+                                error: true,
+                                message: err,
+                                field: bound_field
+                            });
+                        } else {
+                            resolve({ error: false });
+                        }
+                    };
+                });
+            }
             var forceValidation = some(b.validators || [], function (validator) {
                 return validator.forceValidation;
             });
@@ -61,6 +82,8 @@ exports.string = function (options) {
                     callback(err, b);
                 });
             }
+
+            return returnValue;
         };
         return b;
     };

--- a/lib/forms.js
+++ b/lib/forms.js
@@ -49,6 +49,26 @@ exports.create = function (fields, options) {
             }, {});
             b.validate = function () {
                 var callback = arguments.length > 1 ? arguments[1] : arguments[0];
+                var returnValue;
+
+                if (!callback) {
+                    if (typeof Promise !== 'function') {
+                        throw new Error('Callback is required when Promises are unsupported');
+                    }
+                    returnValue = new Promise(function (resolve) {
+                        callback = function (err, form) {
+                            if (form.isValid()) {
+                                resolve({ error: false });
+                            } else {
+                                resolve({
+                                    error: true,
+                                    message: String(err || ''),
+                                    form: form
+                                });
+                            }
+                        };
+                    });
+                }
 
                 asyncForEach(keys(b.fields), function (k, asyncCallback) {
                     b.fields[k].validate(b, function (err, bound_field) {
@@ -58,6 +78,8 @@ exports.create = function (fields, options) {
                 }, function (err) {
                     callback(err, b);
                 });
+
+                return returnValue;
             };
             b.isValid = function () {
                 var form = this;

--- a/test/test-form.js
+++ b/test/test-form.js
@@ -68,7 +68,7 @@ test('bind with missing field in data keeps field in form', function (t) {
 });
 
 test('validate', function (t) {
-    t.plan(11);
+    t.plan(2 + 9);
     var form = forms.create({
         field1: forms.fields.string(),
         field2: forms.fields.string({
@@ -92,7 +92,6 @@ test('validate', function (t) {
         t.notEqual(form, f, 'bind returns new form object');
 
         t.notOk(f.isValid());
-        t.end();
     });
 });
 
@@ -163,7 +162,7 @@ test('validate invalid data', function (t) {
                 callback('validation error 2');
             }]
         })
-    });
+    }, { validatePastFirstError: true });
     formObject.bind({ field1: '1', field2: '2' }).validate(function (err, f) {
         t.equal(f.isValid(), false);
         t.equal(

--- a/test/test-render.js
+++ b/test/test-render.js
@@ -92,7 +92,7 @@ var testWrap = function (tag) {
                     callback('validation error after field');
                 }]
             })
-        });
+        }, { validatePastFirstError: true });
         formObject.bind({ field_name: 'val', field_name_error_after: 'foo' }).validate(function (err, f) {
             t.equal(
                 f.toHTML(forms.render[tag]),
@@ -124,7 +124,7 @@ var testWrap = function (tag) {
                     callback('validation error after field');
                 }]
             })
-        });
+        }, { validatePastFirstError: true });
         f2.bind({ field_name: 'val', field_name_error_after: 'foo' }).validate(function (err, f) {
             t.equal(
                 f.toHTML(forms.render[tag]),
@@ -148,8 +148,6 @@ var testWrap = function (tag) {
                 '<p class="error_msg">validation error after field</p>'
             );
         });
-
-        t.end();
     });
 
     test(tag + ' multipleCheckbox', function (t) {
@@ -295,7 +293,7 @@ test('table bound error', function (t) {
                 callback('validation error after field');
             }]
         })
-    });
+    }, { validatePastFirstError: true });
     formObject.bind({ field_name: 'val', field_name_error_after: 'foo' }).validate(function (err, f) {
         t.equal(
             f.toHTML(forms.render.table),
@@ -331,7 +329,7 @@ test('table bound error', function (t) {
                 callback('validation error after field');
             }]
         })
-    });
+    }, { validatePastFirstError: true });
     f2.bind({ field_name: 'val', field_name_error_after: 'foo' }).validate(function (err, f) {
         t.equal(
             f.toHTML(forms.render.table),
@@ -358,6 +356,4 @@ test('table bound error', function (t) {
             '<p class="error_msg">validation error after field</p>'
         );
     });
-
-    t.end();
 });


### PR DESCRIPTION
Fixes #217 

Also:

* `async` module is removed and replaced with a tiny tiny helper function
* `field.validate()` now always returns an error, previously it only did so on `required` errors
* due to the fact that `field.validate()` rarely returned an error, the functionality of `validatePastFirstError` was pretty much never respected and the tests was also set up to expect `validatePastFirstError` to not function. So in reality `validatePastFirstError` has been active for most cases for most users, so the restoration of it's functionality can almost be a bit breaking 🤔 Any thoughts @ljharb?


Are the tests enough for `form.validate()`? Its getting late here so I'm running out of time a bit, so I'm opening this PR now anyways so that this code won't be stuck on my computer

To do / decide:

- [ ] How to handle a now functional `validatePastFirstError`
- [ ] Update README with these promise variants of `.validate()` and the one from #215 
- [ ] Once released, do the same, but for the types at DefinitelyTyped, or bring the types in here? (Bringing them here would be easier as then they can be updated prior to release)