### PR TITLE
Don't type cast non-sensible values

### DIFF
--- a/lib/fields.js
+++ b/lib/fields.js
@@ -12,6 +12,9 @@ var validators = require('./validators');
 var coerceArray = function (arr) {
     return is.array(arr) && arr.length > 0 ? arr : [];
 };
+var isSingleFieldData = function (raw_data) {
+    return is.string(raw_data) || is.number(raw_data);
+};
 var nameSeparatorRegExp = /[_-]/g;
 
 exports.string = function (options) {
@@ -21,10 +24,7 @@ exports.string = function (options) {
     f.widget = f.widget || forms.widgets.text(opt.attrs || {});
 
     f.parse = function (raw_data) {
-        if (typeof raw_data !== 'undefined' && raw_data !== null) {
-            return String(raw_data);
-        }
-        return '';
+        return isSingleFieldData(raw_data) ? String(raw_data) : '';
     };
     f.bind = function (raw_data) {
         var b = assign({}, f); // clone field object:
@@ -112,10 +112,10 @@ exports.number = function (opt) {
     var f = exports.string(opts);
 
     f.parse = function (raw_data) {
-        if (raw_data === null || raw_data === '') {
+        if (raw_data === '') {
             return NaN;
         }
-        return Number(raw_data);
+        return isSingleFieldData(raw_data) ? Number(raw_data) : NaN;
     };
     return f;
 };
@@ -126,7 +126,10 @@ exports['boolean'] = function (opt) {
 
     f.widget = opts.widget || forms.widgets.checkbox(opts.attrs || {});
     f.parse = function (raw_data) {
-        return !!raw_data;
+        if (is.bool(raw_data)) {
+            return raw_data;
+        }
+        return !!(raw_data && isSingleFieldData(raw_data));
     };
     return f;
 };


### PR DESCRIPTION
Fixes #186 by checking if it's a sensible value before it casts it, so that non-sensible values won't be casted to eg. a string